### PR TITLE
client responsive, closes #28

### DIFF
--- a/src/components/info/InfoCard.vue
+++ b/src/components/info/InfoCard.vue
@@ -1,12 +1,10 @@
 <template>
-  <v-card class="mx-auto" max-width="347" elevation="2">
+  <v-card class="mx-auto d-flex flex-column" min-width="150" elevation="2">
     <v-card-title>{{ title }}</v-card-title>
     <v-card-text>
       <h4 class="font-weight-bold">{{ text }}</h4>
-      <div>
-        <v-icon>{{ icon }}</v-icon>
-      </div>
     </v-card-text>
+    <v-icon class="mt-auto mb-2">{{ icon }}</v-icon>
   </v-card>
 </template>
 

--- a/src/components/info/InfoMain.vue
+++ b/src/components/info/InfoMain.vue
@@ -8,11 +8,11 @@
         </h2>
 
         <v-row justify-md="center">
-          <v-spacer></v-spacer>
-          <v-col v-for="(info, i) in weatherInfo" :key="i">
+          <v-spacer class="d-none d-md-block"></v-spacer>
+          <v-col class="d-flex" v-for="(info, i) in weatherInfo" :key="i">
             <InfoCard v-bind="info" />
           </v-col>
-          <v-spacer></v-spacer>
+          <v-spacer class="d-none d-md-block"></v-spacer>
         </v-row>
       </v-col>
 
@@ -23,11 +23,11 @@
         </h2>
 
         <v-row justify="center">
-          <v-spacer></v-spacer>
-          <v-col v-for="(info, i) in stationsInfo" :key="i">
+          <v-spacer class="d-none d-md-block"></v-spacer>
+          <v-col class="d-flex" v-for="(info, i) in stationsInfo" :key="i">
             <InfoCard v-bind="info" />
           </v-col>
-          <v-spacer></v-spacer>
+          <v-spacer class="d-none d-md-block"></v-spacer>
         </v-row>
       </v-col>
     </v-row>
@@ -48,7 +48,8 @@ export default {
       },
       {
         title: "Compare",
-        text: "Compare various providers to look the world from many eye's points!",
+        text:
+          "Compare various providers to look the world from many eye's points!",
         icon: "mdi-weather-windy-variant",
       },
       {


### PR DESCRIPTION
### Lavoro Svolto
- [x] Le card nella home sono responsive, non si schiacciano più ma vanno a capo e occupano tutta la larghezza
- [x] Le card nella home sono ora della stessa altezza indipendentemente dal testo
- [x] Gli spacer a dx e sx vengono rimossi per schermi piccoli
- [x] Le icone sono sempre allineate in basso, anche con testi brevi

### Schermi Grandi
![Screen Shot 2021-08-22 at 12 41 21](https://user-images.githubusercontent.com/69794393/130352253-1c4a4965-d8cc-4822-a607-e9ec21a59ee2.png)

### Schermi Medi
![Screen Shot 2021-08-22 at 12 41 06](https://user-images.githubusercontent.com/69794393/130352259-2d369845-5b65-4e51-842a-4e54e0a28192.png)

### Schermi Piccoli
![Screen Shot 2021-08-22 at 12 40 57](https://user-images.githubusercontent.com/69794393/130352261-a3c5b6f3-1150-442a-a9cf-cd93e13dac87.png)
